### PR TITLE
use uuid formats with the ajv validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "ajv": "^8.12.0",
+        "ajv-formats": "^2.1.1",
         "json-schema-to-typescript": "^13.0.1"
       }
     },
@@ -82,6 +83,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/any-promise": {
@@ -581,6 +598,14 @@
         "json-schema-traverse": "^1.0.0",
         "require-from-string": "^2.0.2",
         "uri-js": "^4.2.2"
+      }
+    },
+    "ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "requires": {
+        "ajv": "^8.0.0"
       }
     },
     "any-promise": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "license": "ISC",
   "dependencies": {
     "ajv": "^8.12.0",
+    "ajv-formats": "^2.1.1",
     "json-schema-to-typescript": "^13.0.1"
   }
 }

--- a/schemas/7/vault.json
+++ b/schemas/7/vault.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema",
   "$id": "https://uno.app/schemas/7/vault.json",
   "title": "Vault",
   "description": "Uno Vault",
@@ -10,7 +9,8 @@
     "vaultSchemaMajor": { "type": "integer" },
     "vaultSchemaMinor": { "type": "integer" },
     "uuid": {
-      "type": "string"
+      "type": "string",
+      "format": "uuid"
     },
     "email": {
       "type": "string"
@@ -112,7 +112,8 @@
         "phoneNumber": { "type": "string" },
         "state": { "enum": ["denied", "error", "pending", "protecting", "recovery", "removing", "owner", "readonly"] },
         "id": { 
-          "type": "string"
+          "type": "string",
+          "format": "uuid"
         },
         "share": { "type": "string" },
         "signingKey": { "type": "string" },
@@ -137,7 +138,8 @@
       "additionalProperties": false,
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "format": "uuid"
         },
         "clientId": { "type": "string" },
         "refreshToken": { "type": "string" }
@@ -149,7 +151,8 @@
       "additionalProperties": false,
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "format": "uuid"
         },
         "title": { "type": "string" },
         "notes": { "type": "string" }
@@ -161,7 +164,8 @@
       "additionalProperties": false,
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "format": "uuid"
         },
         "line1": { "type": "string" },
         "line2": { "type": "string" },
@@ -177,7 +181,8 @@
       "additionalProperties": false,
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "format": "uuid"
         },
         "type": { "type": "string" },
         "name": { "type": "string" },
@@ -193,7 +198,8 @@
           "maxLength": 4
         },
         "addressUUID": {
-          "type": "string"
+          "type": "string",
+          "format": "uuid"
         }
       },
       "required": ["id", "holder", "number", "expiration"]
@@ -203,7 +209,8 @@
       "additionalProperties": false,
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "format": "uuid"
         },
         "seed": { "type": "string" },
         "ownerPublicSigningKey": { "type": "string" }
@@ -224,7 +231,8 @@
         "notes": { "type": "string" },
         "url": { "type": "string" },
         "id": {
-          "type": "string"
+          "type": "string",
+          "format": "uuid"
         }
       },
       "required": ["name", "key", "id"]
@@ -252,7 +260,8 @@
       "additionalProperties": false,
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "format": "uuid"
         },
         "name": { "type": "string" },
         "username": { "type": "string" },
@@ -281,7 +290,8 @@
       "additionalProperties": false,
       "properties": {
         "id": {
-          "type": "string"
+          "type": "string",
+          "format": "uuid"
         },
         "matching_hosts": { "type": "array", "items": { "type": "string" } },
         "name": { "type": "string" },

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,4 +1,5 @@
 const Ajv = require("ajv");
+const formats = require("ajv-formats");
 const fs = require("fs");
 
 (function() {
@@ -25,6 +26,7 @@ const fs = require("fs");
   const schema = JSON.parse(schemaBuf);
 
   const ajv = new Ajv();
+  formats(ajv);
   const validate = ajv.compile(schema);
 
   let data;


### PR DESCRIPTION
restore uuid format support. Also we don't need to specify the schema version in our actual schema. It will either validate or not with some specified validator package: for example ajv will handle draft-07 by default